### PR TITLE
Sport and Culture Cardlist added for APRO

### DIFF
--- a/data/ch/chandigarh/Dashboard/dashboardCardList.json
+++ b/data/ch/chandigarh/Dashboard/dashboardCardList.json
@@ -4,7 +4,7 @@
   "dashboardCardList": [
 	{
 	"cardName" : "Pgr_dashboard_1",
-	"roles": ["EMPLOYEE"],
+	"roles": ["GRO"],
 	"icon": "material-icons module-page-icon",
 	"route": "PGRDashboard"
 	},
@@ -19,6 +19,12 @@
 	"roles": ["challanSI"],
 	"icon": "material-icons module-page-icon",
 	"route": "EChallanDashboard"
+	},
+	{
+	  "cardName": "Sport&Culture_dashboard_1",
+	  "roles": ["APRO"],
+	  "icon": "material-icons module-page-icon",
+	  "route": "SportCultureDashboard"
 	}
   ]
 }


### PR DESCRIPTION
1. Added Dashboard Card for APRO login.
2. Replace the card access for GRO = Employee to GRO.
   ( PGR dashboard Card come with every module dashboard )